### PR TITLE
Make link to taxonomy editor open in new window

### DIFF
--- a/inc/post-type/edit.php
+++ b/inc/post-type/edit.php
@@ -371,7 +371,7 @@ class MB_CPT_Post_Type_Edit extends MB_CPT_Base_Edit {
 						'post_tag' => __( 'Tag', 'mb-custom-post-type' ),
 					),
 					// translators: %s: Link to edit taxonomies page.
-					'desc'    => sprintf( __( 'Add default taxonomies to post type. For custom taxonomies, please <a href="%s">click here</a>.', 'mb-custom-post-type' ), admin_url( 'edit.php?post_type=mb-taxonomy' ) ),
+					'desc'    => sprintf( __( 'Add default taxonomies to post type. For custom taxonomies, please <a href="%s" target="_blank">click here</a>.', 'mb-custom-post-type' ), admin_url( 'edit.php?post_type=mb-taxonomy' ) ),
 				),
 			),
 		);


### PR DESCRIPTION
Added `target="_blank"` to the "click here" link on the post type editor screen. I lost a taxonomy and had to re-create it after clicking that link :(